### PR TITLE
* fix bug when ‘nn.hessian.enable()’ the function self:parameters() w…

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -11,7 +11,7 @@ function Module:updateParameters(learningRate)
    local params, gradParams, scales = self:sparseParameters()
    if params then
       for i,param in pairs(params) do -- pairs for sparse params
-         local scale = scales and scales[i] or 1
+         local scale = scales and scales[i] and type(scales[i]) == "number" or 1
          param:add(-learningRate*scale, gradParams[i])
       end
    end


### PR DESCRIPTION
when ‘nn.hessian.enable()’ the function self:parameters() will return 3 results and last one is diagonal elements. not the scale
detail:
nn.hessian.lua

   function nn.Module.parameters(self)
      if self.weight and self.bias then
         return {self.weight, self.bias}, {self.gradWeight, self.gradBias}, {self.diagHessianWeight, self.diagHessianBias}
      elseif self.weight then
         return {self.weight}, {self.gradWeight}, {self.diagHessianWeight}
      elseif self.bias then
         return {self.bias}, {self.gradBias}, {self.diagHessianBias}
      else
         return
      end
   end

